### PR TITLE
Fix closing tag in fleet_q shortcode

### DIFF
--- a/templates/shortcodes/fleet_q.html
+++ b/templates/shortcodes/fleet_q.html
@@ -4,13 +4,13 @@
         <p style="font-size: 1rem;">{{ body | safe }}</p>
         <div style="display: flex; justify-content: right;">
           <p style="font-size: 1rem">
-          <span>—&nbsp;</span>
-          {% if link %}
-          <a href="{{ link }}">{{ source_name }}</a>
-          {% else %}
-          {{ source_name }}
+            <span>—&nbsp;</span>
+            {% if link %}
+            <a href="{{ link }}">{{ source_name }}</a>
+            {% else %}
+            {{ source_name }}
+            {% endif %}
           </p>
-          {% endif %}
         </div>
     </blockquote>
 </div>


### PR DESCRIPTION
## Summary
- fix misplaced `</p>` in the `fleet_q` shortcode so that
  paragraphs close correctly when a link is present

## Testing
- `zola build` *(fails: `zola: command not found`)*