### PR TITLE
Add Zola build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Zola Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      ZOLA_VERSION: "0.19.2"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install Zola
+        run: |
+          ZOLA_URL="https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -L "$ZOLA_URL" | tar -xz -C /tmp
+          sudo mv /tmp/zola /usr/local/bin/zola
+          zola --version
+      - name: Build site
+        run: zola build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Pinchlime Site
+
+This repository contains the source for a static site built with [Zola](https://www.getzola.org/).
+
+## Continuous Integration
+
+A GitHub Actions workflow is provided at `.github/workflows/build.yml` to verify that the site builds successfully. The job installs Zola version 0.19.2 and runs `zola build`. Any build failures will cause the workflow to fail.
+


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs Zola 0.19.2 and builds the site
- document the workflow in a new README

## Testing
- `git status --short`