### PR TITLE
Enable basic multilingual site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,3 +28,12 @@ twitter_user = "@WuPingJu"
 [slugify]
 paths = "on"
 taxonomies = "on"
+
+[languages.zh-TW]
+title = "Pin 起來！"
+description = "介紹生產力工具，以及分享使用心得"
+
+[languages.en]
+title = "Pinchlime"
+description = "Productivity tools and workflow articles"
+

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,0 +1,12 @@
+---
+transparent: true
+generate_feeds: true
+title: Pinchlime
+---
+
+# Pinchlime
+
+Welcome to **Pinchlime**. I'm PJ Wu, currently working as a Customer Experience Manager at [Heptabase](https://get.heptabase.com/pinchlime). Here I share thoughts, interests, and experiences.
+
+This site does not sell knowledge anxiety. If you share similar interests or values, I hope you find something useful here.
+

--- a/content/en/pages/about.md
+++ b/content/en/pages/about.md
@@ -1,0 +1,16 @@
+---
+title: About PJ Wu and Pinchlime
+path: about/
+date: 2025-01-13
+updated: 2025-03-10
+description: This site is my personal blog where I share thoughts on productivity tools and workflows.
+extra:
+  page_type: single
+---
+
+## About Me
+
+I'm PJ Wu. PJ comes from my given name "Ping Ju". Feel free to call me PJ when you reach out.
+
+Currently I work at Heptabase as a Customer Experience Manager. I enjoy the product so much that I decided to join the team.
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -94,6 +94,15 @@
             <a class="menu-button" href="/manifesto/">Manifesto</a>
             <a class="menu-button" href="/changelog/">Changelog</a>
           </div>
+          {% if config.languages and config.languages | length > 1 %}
+          <div class="language-switcher">
+            {% for code in config.languages | keys %}
+              {% if code != lang %}
+              <a class="menu-button" href="{{ get_url(path="/", lang=code) }}">{{ code }}</a>
+              {% endif %}
+            {% endfor %}
+          </div>
+          {% endif %}
         </div>
       </nav>
       {% endblock nav_bar %}


### PR DESCRIPTION
## Summary
- configure Zola with `languages` table
- add English translations for index and about page
- show language switcher in site navigation

## Testing
- `zola build` *(fails: command not found)*